### PR TITLE
Updated the Graph API call to /taggable_friends since the /friends api call was deprecated by Facebook

### DIFF
--- a/fb_friends.py
+++ b/fb_friends.py
@@ -5,28 +5,28 @@ import webbrowser
 from pprint import pprint
 
 token = ''
-api_url = 'https://graph.facebook.com/v2.1/'
+api_url = 'https://graph.facebook.com/v2.7/'
 params = {'access_token' : token}
 
 
 def extractFriends():
-    call = "me/friends?fields=picture.width(9999).height(9999).type(large),gender,name"
+    call = "me/taggable_friends?fields=name,picture.width(9999).height(9999).type(large)&limit=5000"
     response = requests.get(api_url + call, params=params)
     r = (json.loads(response.content))
     #pprint(r)
     for f in r['data']:
-        #print f['name'], f['gender']
+        #print f['name']
         p_url = str(f['picture']['data']['url'])
         #print p_url
-        
+
         opener1 = urllib2.build_opener()
         page1 = opener1.open(p_url)
         my_picture = page1.read()
 
         filename = f['name']+"_"+f['id']+".jpg"
-        print filename+" downloaded..."
+        print(filename + " downloaded...")
         fout = open('images/'+filename, "wb")
         fout.write(my_picture)
         fout.close()
-        
+
 extractFriends()


### PR DESCRIPTION
Updated the Graph API call to /taggable_friends since the /friends api call was deprecated by Facebook
